### PR TITLE
Path Compute Optimization

### DIFF
--- a/Grid-Astar-Game/code/Actors/BaseActor.Navigation.cs
+++ b/Grid-Astar-Game/code/Actors/BaseActor.Navigation.cs
@@ -1,17 +1,18 @@
 ﻿using GridAStar;
+using System.Collections.Immutable;
 
 namespace GridAStarNPC;
 
 public abstract partial class BaseActor
 {
-	internal List<GridAStar.Cell> currentPath { get; set; } = new List<GridAStar.Cell>();
-	public int CurrentPathLength => currentPath.Count;
+	internal ImmutableArray<GridAStar.Cell> currentPath { get; set; } = ImmutableArray<Cell>.Empty;
+	public int CurrentPathLength => currentPath.Length;
 	internal int currentPathIndex { get; set; } = -1; // -1 = Not set / Hasn't started
 	internal GridAStar.Cell currentPathCell => IsFollowingPath ? currentPath[currentPathIndex] : null;
-	internal GridAStar.Cell lastPathCell => currentPath.Count > 0 ? currentPath.Last() : null;
+	internal GridAStar.Cell lastPathCell => currentPath.Length > 0 ? currentPath[^1] : null;
 	internal GridAStar.Cell targetPathCell { get; set; } = null;
-	internal GridAStar.Cell nextPathCell => IsFollowingPath ? currentPath[Math.Min( currentPathIndex + 1, currentPath.Count - 1 )] : null;
-	public bool IsFollowingPath => currentPathIndex >= 0 && currentPath.Count > 0;
+	internal GridAStar.Cell nextPathCell => IsFollowingPath ? currentPath[Math.Min( currentPathIndex + 1, currentPath.Length - 1 )] : null;
+	public bool IsFollowingPath => currentPathIndex >= 0 && currentPath.Length > 0;
 	[Net] public BaseActor Following { get; set; } = null;
 	public bool IsFollowingSomeone => Following != null;
 	public bool HasArrivedDestination { get; internal set; } = false;
@@ -28,16 +29,16 @@ public abstract partial class BaseActor
 		if ( targetCell == null ) return false;
 		if ( targetCell == NearestCell ) return false;
 
-		var computedPath = await CurrentGrid.ComputePath( NearestCell, targetCell );
+		var computedPath = await CurrentGrid.ComputePathAsync( NearestCell, targetCell );
 
-		if ( computedPath == null || computedPath.Count < 1 ) return false;
+		if ( computedPath == null || computedPath.Length < 1 ) return false;
 
 		currentPath = computedPath;
 		currentPathIndex = 0;
 		HasArrivedDestination = false;
 		targetPathCell = lastPathCell;
 
-		for ( int i = 0; i < computedPath.Count; i++ )
+		for ( int i = 0; i < computedPath.Length; i++ )
 		{
 			computedPath[i].Draw( Color.Red, 3, false );
 			DebugOverlay.Text( i.ToString(), computedPath[i].Position, duration: 3 );
@@ -76,7 +77,7 @@ public abstract partial class BaseActor
 		if ( Position.DistanceSquared( nextPathCell.Position ) <= (CurrentGrid.CellSize / 2 ) * (CurrentGrid.CellSize / 2 ) )
 			currentPathIndex++;
 
-		if ( currentPathIndex >= currentPath.Count || currentPathCell == targetPathCell )
+		if ( currentPathIndex >= currentPath.Length || currentPathCell == targetPathCell )
 		{
 			HasArrivedDestination = true;
 			currentPathIndex = -1;

--- a/Grid-Astar-Library/code/Cell.cs
+++ b/Grid-Astar-Library/code/Cell.cs
@@ -1,6 +1,6 @@
 ﻿namespace GridAStar;
 
-public partial class Cell
+public partial class Cell : IEquatable<Cell>
 {
 	/// <summary>
 	/// The parent grid

--- a/Grid-Astar-Library/code/Cell.cs
+++ b/Grid-Astar-Library/code/Cell.cs
@@ -163,25 +163,23 @@ public partial class Cell
 		return true;
 	}
 
-	public List<Cell> GetNeighbours( bool ignoreHeight = false )
+	public IEnumerable<Cell> GetNeighbours( bool ignoreHeight = false )
 	{
-		var neighbours = new List<Cell>();
-		
-		for( int y = -1; y <= 1; y++ )
+		var height = ignoreHeight ? float.MaxValue : Position.z;
+
+		for ( int y = -1; y <= 1; y++ )
 		{
 			for ( int x = -1; x <= 1; x++ )
 			{
 				if ( x == 0 && y == 0 ) continue;
 
-				var cellFound = Grid.GetCell( new IntVector2( GridPosition.x + x, GridPosition.y + y ), ignoreHeight ? float.MaxValue : Position.z );
+				var cellFound = Grid.GetCell( new IntVector2( GridPosition.x + x, GridPosition.y + y ), height );
 				if ( cellFound == null ) continue;
 
 				if ( IsNeighbour( cellFound ) )
-					neighbours.Add( cellFound );
+					yield return cellFound;
 			}
 		}
-
-		return neighbours;
 	}
 
 	/// <summary>

--- a/Grid-Astar-Library/code/Grid.Debug.cs
+++ b/Grid-Astar-Library/code/Grid.Debug.cs
@@ -62,7 +62,7 @@ public partial class Grid
 	{
 		foreach ( var client in Game.Clients )
 		{
-			var cells = await Grid.Main.ComputePathParallel( Grid.Main, client.Pawn.Position, Vector3.Random * 3000f, true );
+			var cells = await Grid.Main.ComputePathParallel( client.Pawn.Position, Vector3.Random * 3000f, true );
 
 			for ( int i = 0; i < cells.Length; i++ )
 			{

--- a/Grid-Astar-Library/code/Grid.Debug.cs
+++ b/Grid-Astar-Library/code/Grid.Debug.cs
@@ -62,7 +62,7 @@ public partial class Grid
 		{
 			var cells = await Grid.Main.ComputePathParallel( Grid.Main, client.Pawn.Position, Vector3.Random * 3000f, true );
 
-			for ( int i = 0; i < cells.Count; i++ )
+			for ( int i = 0; i < cells.Length; i++ )
 			{
 				cells[i].Draw( Color.Red, 3, false );
 				DebugOverlay.Text( i.ToString(), cells[i].Position, duration: 3 );

--- a/Grid-Astar-Library/code/Grid.Debug.cs
+++ b/Grid-Astar-Library/code/Grid.Debug.cs
@@ -1,4 +1,6 @@
-﻿namespace GridAStar;
+﻿using System.Collections.Immutable;
+
+namespace GridAStar;
 
 public partial class Grid
 {
@@ -66,6 +68,53 @@ public partial class Grid
 			{
 				cells[i].Draw( Color.Red, 3, false );
 				DebugOverlay.Text( i.ToString(), cells[i].Position, duration: 3 );
+			}
+		}
+	}
+
+	[ConCmd.Server( "StressPath" )]
+	public static async void StressPath( int runs = 100, int seed = 42069 )
+	{
+		var firstPlayer = Game.Clients.FirstOrDefault();
+		if ( firstPlayer is null )
+		{
+			Log.Warning( "There needs to be at least one player in the server for this to be used" );
+			return;
+		}
+
+		var random = new Random( seed );
+		var times = new double[runs];
+		var paths = new ImmutableArray<Cell>[runs];
+
+		var startingPosition = firstPlayer.Position;
+		for ( var i = 0; i < runs; i++ )
+		{
+			var targetPosition = new Vector3( random.Float( -1, 1 ), random.Float( -1, 1 ), random.Float( -1, 1 ) ) * 3000;
+
+			var startingCell = Grid.Main.GetCell( startingPosition, false );
+			var targetCell = Grid.Main.GetCell( targetPosition, false );
+
+			var timestamp = Stopwatch.GetTimestamp();
+			var path = await Grid.Main.ComputePathParallel( startingCell, targetCell );
+			var elapsed = Stopwatch.GetElapsedTime( timestamp );
+
+			times[i] = elapsed.TotalMilliseconds;
+			paths[i] = path;
+			Log.Info( $"Finished run #{i + 1}" );
+		}
+
+		Log.Info( $"-- {runs} Runs --" );
+		Log.Info( $"Fastest Run: {times.Min()}ms" );
+		Log.Info( $"Slowest Run: {times.Max()}ms" );
+		Log.Info( $"Average: {times.Average()}ms" );
+		Log.Info( $"Total Time: {times.Sum()}ms" );
+
+		foreach ( var path in paths )
+		{
+			for ( var i = 0; i < path.Length; i++ )
+			{
+				path[i].Draw( Color.Red, 10, false );
+				DebugOverlay.Text( i.ToString(), path[i].Position, duration: 10 );
 			}
 		}
 	}

--- a/Grid-Astar-Library/code/Grid.Nav.cs
+++ b/Grid-Astar-Library/code/Grid.Nav.cs
@@ -5,46 +5,88 @@ namespace GridAStar;
 
 public partial class Grid
 {
+	/// <summary>
+	/// Computes a path from the starting point to a target point on another thread.
+	/// </summary>
+	/// <param name="startingCell">The starting point of the path.</param>
+	/// <param name="targetCell">The desired destination point of the path.</param>
+	/// <returns>A task that represents the asynchronous operation. The result of the task is an <see cref="ImmutableArray{Cell}"/> that contains the computed path.</returns>
 	public async Task<ImmutableArray<Cell>> ComputePathAsync( Cell startingCell, Cell targetCell )
 	{
+		// Fast path.
 		if ( startingCell is null || targetCell is null || startingCell == targetCell ) return ImmutableArray<Cell>.Empty;
 
-		return await GameTask.RunInThreadAsync( () => ComputePathInternal( startingCell, targetCell, false, default ) );
+		return await GameTask.RunInThreadAsync( () => ComputePathInternal( startingCell, targetCell, false, CancellationToken.None ) );
 	}
 
+	/// /// <summary>
+	/// Computes a path from the starting point to a target point on another thread.
+	/// </summary>
+	/// <param name="startingCell">The starting point of the path.</param>
+	/// <param name="targetCell">The desired destination point of the path.</param>
+	/// <param name="token">A cancellation token used to cancel computing the path.</param>
+	/// <returns>A task that represents the asynchronous operation. The result of the task is an <see cref="ImmutableArray{Cell}"/> that contains the computed path.</returns>
 	public async Task<ImmutableArray<Cell>> ComputePathAsync( Cell startingCell, Cell targetCell, CancellationToken token )
 	{
+		// Fast path.
 		if ( startingCell is null || targetCell is null || startingCell == targetCell ) return ImmutableArray<Cell>.Empty;
 
 		return await GameTask.RunInThreadAsync( () => ComputePathInternal( startingCell, targetCell, false, token ) );
 	}
 
+	/// <summary>
+	/// Computes a path from the starting point to a target point on another thread.
+	/// </summary>
+	/// <param name="startingCell">The starting point of the path.</param>
+	/// <param name="targetCell">The desired destination point of the path.</param>
+	/// <param name="reversed">Whether or not to reverse the resulting path.</param>
+	/// <param name="token">A cancellation token used to cancel computing the path.</param>
+	/// <returns>A task that represents the asynchronous operation. The result of the task is an <see cref="ImmutableArray{Cell}"/> that contains the computed path.</returns>
 	public async Task<ImmutableArray<Cell>> ComputePathAsync( Cell startingCell, Cell targetCell, bool reversed = false, CancellationToken token = default )
 	{
+		// Fast path.
 		if ( startingCell is null || targetCell is null || startingCell == targetCell ) return ImmutableArray<Cell>.Empty;
 
 		return await GameTask.RunInThreadAsync( () => ComputePathInternal( startingCell, targetCell, reversed, token ) );
 	}
 
+	/// <summary>
+	/// Computes a path from the starting point to a target point.
+	/// </summary>
+	/// <param name="startingCell">The starting point of the path.</param>
+	/// <param name="targetCell">The desired destination point of the path.</param>
+	/// <param name="reversed">Whether or not to reverse the resulting path.</param>
+	/// <returns>An <see cref="ImmutableArray{Cell}"/> that contains the computed path.</returns>
 	public ImmutableArray<Cell> ComputePath( Cell startingCell, Cell targetCell, bool reversed = false )
 	{
+		// Fast path.
 		if ( startingCell is null || targetCell is null || startingCell == targetCell ) return ImmutableArray<Cell>.Empty;
 
-		return ComputePathInternal( startingCell, targetCell, reversed, default );
+		return ComputePathInternal( startingCell, targetCell, reversed, CancellationToken.None );
 	}
 
-	private ImmutableArray<Cell> ComputePathInternal( Cell startingCell, Cell targetCell, bool reversed, CancellationToken token = default )
+	/// <summary>
+	/// Computes a path from the starting point to a target point. Reversing the path if needed.
+	/// </summary>
+	/// <param name="startingCell">The starting point of the path.</param>
+	/// <param name="targetCell">The desired destination point of the path.</param>
+	/// <param name="reversed">Whether or not to reverse the resulting path.</param>
+	/// <param name="token">A cancellation token used to cancel computing the path.</param>
+	/// <returns>An <see cref="ImmutableArray{Cell}"/> that contains the computed path.</returns>
+	private ImmutableArray<Cell> ComputePathInternal( Cell startingCell, Cell targetCell, bool reversed, CancellationToken token )
 	{
+		// Setup.
 		var path = ImmutableArray.CreateBuilder<Cell>();
 
 		var startingNode = new Node( startingCell );
 		var targetNode = new Node( targetCell );
 
-		Heap<Node> openSet = new( Cells.Count );
-		HashSet<Node> closedSet = new();
-		HashSet<Cell> closedCellSet = new();
-		HashSet<Cell> openCellSet = new();
-		Dictionary<Cell, Node> cellNodePair = new();
+		var openSet = new Heap<Node>( Cells.Count );
+		var closedSet = new HashSet<Node>();
+		var closedCellSet = new HashSet<Cell>();
+		var openCellSet = new HashSet<Cell>();
+		var cellNodePair = new Dictionary<Cell, Node>();
+
 		openSet.Add( startingNode );
 		openCellSet.Add( startingCell );
 		cellNodePair.Add( startingCell, startingNode );
@@ -67,7 +109,7 @@ public partial class Grid
 			{
 				if ( neighbour.Occupied || closedCellSet.Contains( neighbour ) ) continue;
 
-				bool isInOpenSet = openCellSet.Contains( neighbour );
+				var isInOpenSet = openCellSet.Contains( neighbour );
 				Node neighbourNode;
 
 				if ( isInOpenSet )
@@ -75,7 +117,7 @@ public partial class Grid
 				else
 					neighbourNode = new Node( neighbour );
 
-				float newMovementCostToNeighbour = currentNode.gCost + currentNode.Distance( neighbour );
+				var newMovementCostToNeighbour = currentNode.gCost + currentNode.Distance( neighbour );
 
 				if ( newMovementCostToNeighbour < neighbourNode.gCost || !isInOpenSet )
 				{
@@ -102,8 +144,17 @@ public partial class Grid
 		return path.ToImmutable();
 	}
 
+	/// <summary>
+	/// Computes a path from the starting point to a target point and vice versa simultaneously.
+	/// </summary>
+	/// <param name="startingCell">The starting point of the path.</param>
+	/// <param name="targetCell">The desired destination point of the path.</param>
+	/// <returns>A task that represents the asynchronous operation. The result of the task is an <see cref="ImmutableArray{Cell}"/> that contains the computed path.</returns>
 	public async Task<ImmutableArray<Cell>> ComputePathParallel( Cell startingCell, Cell targetCell )
 	{
+		// Fast path.
+		if ( startingCell is null || targetCell is null || startingCell == targetCell ) return ImmutableArray<Cell>.Empty;
+
 		var ctoken = new CancellationTokenSource();
 
 		var fromTo = ComputePathAsync( startingCell, targetCell, ctoken.Token );
@@ -111,26 +162,25 @@ public partial class Grid
 
 		var pathResult = await GameTask.WhenAny( fromTo, toFrom ).Result;
 
+		// Cancel the other task that hasn't finished yet.
 		ctoken.Cancel();
 
 		return pathResult;
 	}
 
-	public async Task<ImmutableArray<Cell>> ComputePathParallel( Grid grid, Vector3 startingPosition, Vector3 targetPosition, bool findClosest = false )
+	/// <summary>
+	/// Computes a path from a starting <see cref="Vector3"/> to a target <see cref="Vector3"/> and vice versa simultaneously.
+	/// </summary>
+	/// <param name="startingPosition">A starting world position.</param>
+	/// <param name="targetPosition">A target world position.</param>
+	/// <param name="findClosest">Whether or not to find a cell that is closest to the position.</param>
+	/// <returns>A task that represents the asynchronous operation. The result of the task is an <see cref="ImmutableArray{Cell}"/> that contains the computed path.</returns>
+	public async Task<ImmutableArray<Cell>> ComputePathParallel( Vector3 startingPosition, Vector3 targetPosition, bool findClosest = false )
 	{
-		var ctoken = new CancellationTokenSource();
+		var startingCell = GetCell( startingPosition, findClosest );
+		var targetCell = GetCell( targetPosition, findClosest );
 
-		var startingCell = grid.GetCell( startingPosition, findClosest );
-		var targetCell = grid.GetCell( targetPosition, findClosest );
-
-		var fromTo = ComputePathAsync( startingCell, targetCell, ctoken.Token );
-		var toFrom = ComputePathAsync( targetCell, startingCell, true, ctoken.Token );
-
-		var pathResult = await GameTask.WhenAny( fromTo, toFrom ).Result;
-
-		ctoken.Cancel();
-
-		return pathResult;
+		return await ComputePathParallel( startingCell, targetCell );
 	}
 
 	private static void RetracePath( ImmutableArray<Cell>.Builder pathList, Node startNode, Node targetNode )

--- a/Grid-Astar-Library/code/Grid.Nav.cs
+++ b/Grid-Astar-Library/code/Grid.Nav.cs
@@ -1,28 +1,46 @@
-﻿using System.Threading;
+﻿using System.Collections.Immutable;
+using System.Threading;
 
 namespace GridAStar;
 
 public partial class Grid
 {
-
-	/// <summary>
-	/// Return a list of neighbouring cells that form a path from the start to the target
-	/// </summary>
-	/// <param name="startingCell"></param>
-	/// <param name="targetCell"></param>
-	/// <param name="token"></param>
-	/// <param name="reversed"></param>
-	/// <returns></returns>
-	public async Task<List<Cell>> ComputePath( Cell startingCell, Cell targetCell, CancellationToken token, bool reversed = false )
+	public async Task<ImmutableArray<Cell>> ComputePathAsync( Cell startingCell, Cell targetCell )
 	{
-		List<Cell> finalPath = new();
+		if ( startingCell is null || targetCell is null || startingCell == targetCell ) return ImmutableArray<Cell>.Empty;
 
-		if ( startingCell == null || targetCell == null ) return finalPath; // Escape if invalid end position Ex. if FindNearestDestination is false
+		return await GameTask.RunInThreadAsync( () => ComputePathInternal( startingCell, targetCell, false, default ) );
+	}
+
+	public async Task<ImmutableArray<Cell>> ComputePathAsync( Cell startingCell, Cell targetCell, CancellationToken token )
+	{
+		if ( startingCell is null || targetCell is null || startingCell == targetCell ) return ImmutableArray<Cell>.Empty;
+
+		return await GameTask.RunInThreadAsync( () => ComputePathInternal( startingCell, targetCell, false, token ) );
+	}
+
+	public async Task<ImmutableArray<Cell>> ComputePathAsync( Cell startingCell, Cell targetCell, bool reversed = false, CancellationToken token = default )
+	{
+		if ( startingCell is null || targetCell is null || startingCell == targetCell ) return ImmutableArray<Cell>.Empty;
+
+		return await GameTask.RunInThreadAsync( () => ComputePathInternal( startingCell, targetCell, reversed, token ) );
+	}
+
+	public ImmutableArray<Cell> ComputePath( Cell startingCell, Cell targetCell, bool reversed = false )
+	{
+		if ( startingCell is null || targetCell is null || startingCell == targetCell ) return ImmutableArray<Cell>.Empty;
+
+		return ComputePathInternal( startingCell, targetCell, reversed, default );
+	}
+
+	private ImmutableArray<Cell> ComputePathInternal( Cell startingCell, Cell targetCell, bool reversed, CancellationToken token = default )
+	{
+		var path = ImmutableArray.CreateBuilder<Cell>();
 
 		var startingNode = new Node( startingCell );
 		var targetNode = new Node( targetCell );
 
-		Heap<Node> openSet = new Heap<Node>( Cells.Count );
+		Heap<Node> openSet = new( Cells.Count );
 		HashSet<Node> closedSet = new();
 		HashSet<Cell> closedCellSet = new();
 		HashSet<Cell> openCellSet = new();
@@ -32,114 +50,64 @@ public partial class Grid
 		cellNodePair.Add( startingCell, startingNode );
 		cellNodePair.Add( targetCell, targetNode );
 
-		await GameTask.RunInThreadAsync( () =>
+		while ( openSet.Count > 0 && !token.IsCancellationRequested )
 		{
-			while ( openSet.Count > 0 && !token.IsCancellationRequested )
+			var currentNode = openSet.RemoveFirst();
+			closedSet.Add( currentNode );
+			openCellSet.Remove( currentNode.Current );
+			closedCellSet.Add( currentNode.Current );
+
+			if ( currentNode.Current == targetNode.Current )
 			{
-				var currentNode = openSet.RemoveFirst();
-				closedSet.Add( currentNode );
-				openCellSet.Remove( currentNode.Current );
-				closedCellSet.Add( currentNode.Current );
+				RetracePath( path, startingNode, currentNode );
+				break;
+			}
 
-				if ( currentNode.Current == targetNode.Current )
+			foreach ( var neighbour in currentNode.Current.GetNeighbours() )
+			{
+				if ( neighbour.Occupied || closedCellSet.Contains( neighbour ) ) continue;
+
+				bool isInOpenSet = openCellSet.Contains( neighbour );
+				Node neighbourNode;
+
+				if ( isInOpenSet )
+					neighbourNode = cellNodePair[neighbour];
+				else
+					neighbourNode = new Node( neighbour );
+
+				float newMovementCostToNeighbour = currentNode.gCost + currentNode.Distance( neighbour );
+
+				if ( newMovementCostToNeighbour < neighbourNode.gCost || !isInOpenSet )
 				{
-					retracePath( ref finalPath, startingNode, currentNode );
-					break;
-				}
+					neighbourNode.gCost = newMovementCostToNeighbour;
+					neighbourNode.hCost = neighbourNode.Distance( targetCell );
+					neighbourNode.Parent = currentNode;
 
-				foreach ( var neighbour in currentNode.Current.GetNeighbours() )
-				{
-					if ( neighbour.Occupied || closedCellSet.Contains( neighbour ) ) continue;
-
-					bool isInOpenSet = openCellSet.Contains( neighbour );
-					Node neighbourNode;
-
-					if ( isInOpenSet )
-						neighbourNode = cellNodePair[neighbour];
-					else
-						neighbourNode = new Node( neighbour );
-
-					float newMovementCostToNeighbour = currentNode.gCost + currentNode.Distance( neighbour );
-
-					if ( newMovementCostToNeighbour < neighbourNode.gCost || !isInOpenSet )
+					if ( !isInOpenSet )
 					{
-						neighbourNode.gCost = newMovementCostToNeighbour;
-						neighbourNode.hCost = neighbourNode.Distance( targetCell );
-						neighbourNode.Parent = currentNode;
-
-						if ( !isInOpenSet )
-						{
-							openSet.Add( neighbourNode );
-							openCellSet.Add( neighbour );
-							if ( !cellNodePair.ContainsKey( neighbour ) )
-								cellNodePair.Add( neighbour, neighbourNode );
-							else
-								cellNodePair[neighbour] = neighbourNode;
-						}
+						openSet.Add( neighbourNode );
+						openCellSet.Add( neighbour );
+						if ( !cellNodePair.ContainsKey( neighbour ) )
+							cellNodePair.Add( neighbour, neighbourNode );
+						else
+							cellNodePair[neighbour] = neighbourNode;
 					}
 				}
 			}
-		} );
+		}
 
-		if ( token.IsCancellationRequested )
-			return null;
-		
 		if ( reversed )
-			finalPath.Reverse();
+			path.Reverse();
 
-		return finalPath;
+		return path.ToImmutable();
 	}
 
-	/// <summary>
-	///  Return a list of neighbouring cells that form a path from the start to the target
-	/// </summary>
-	/// <param name="startingCell"></param>
-	/// <param name="targetCell"></param>
-	/// <param name="reversed"></param>
-	/// <returns></returns>
-	public async Task<List<Cell>> ComputePath( Cell startingCell, Cell targetCell, bool reversed = false ) => await ComputePath( startingCell, targetCell, CancellationToken.None, reversed );
-
-	/// <summary>
-	/// Return a list of neighbouring cells that form a path from the start to the target
-	/// </summary>
-	/// <param name="grid"></param>
-	/// <param name="startingPosition"></param>
-	/// <param name="targetPosition"></param>
-	/// <param name="token"></param>
-	/// <param name="findClosest"></param>
-	/// <param name="reversed"></param>
-	/// <returns></returns>
-	public async Task<List<Cell>> ComputePath( Grid grid, Vector3 startingPosition, Vector3 targetPosition, CancellationToken token, bool findClosest = false, bool reversed = false )
-	{
-		var startingCell = grid.GetCell( startingPosition, findClosest );
-		var targetCell = grid.GetCell( targetPosition, findClosest );
-
-		return await ComputePath( startingCell, targetCell, token , reversed );
-	}
-
-	/// <summary>
-	/// Return a list of neighbouring cells that form a path from the start to the target
-	/// </summary>
-	/// <param name="grid"></param>
-	/// <param name="startingPosition"></param>
-	/// <param name="targetPosition"></param>
-	/// <param name="findClosest"></param>
-	/// <param name="reversed"></param>
-	/// <returns></returns>
-	public async Task<List<Cell>> ComputePath( Grid grid, Vector3 startingPosition, Vector3 targetPosition, bool findClosest = false, bool reversed = false ) => await ComputePath( grid, startingPosition, targetPosition, CancellationToken.None, findClosest, reversed );
-
-	/// <summary>
-	/// Compute two paths at the same time, From->To and To->From and return the first one that finishes, can massively speed up on big distances, not much on shorter ones
-	/// </summary>
-	/// <param name="startingCell"></param>
-	/// <param name="targetCell"></param>
-	/// <returns></returns>
-	public async Task<List<Cell>> ComputePathParallel( Cell startingCell, Cell targetCell )
+	public async Task<ImmutableArray<Cell>> ComputePathParallel( Cell startingCell, Cell targetCell )
 	{
 		var ctoken = new CancellationTokenSource();
 
-		var fromTo = ComputePath( startingCell, targetCell, ctoken.Token );
-		var toFrom = ComputePath( targetCell, startingCell, ctoken.Token, true );
+		var fromTo = ComputePathAsync( startingCell, targetCell, ctoken.Token );
+		var toFrom = ComputePathAsync( targetCell, startingCell, true, ctoken.Token );
 
 		var pathResult = await GameTask.WhenAny( fromTo, toFrom ).Result;
 
@@ -148,23 +116,15 @@ public partial class Grid
 		return pathResult;
 	}
 
-	/// <summary>
-	/// Compute two paths at the same time, From->To and To->From and return the first one that finishes, can massively speed up on big distances, not much on shorter ones
-	/// </summary>
-	/// <param name="grid"></param>
-	/// <param name="startingPosition"></param>
-	/// <param name="targetPosition"></param>
-	/// <param name="findClosest"></param>
-	/// <returns></returns>
-	public async Task<List<Cell>> ComputePathParallel( Grid grid, Vector3 startingPosition, Vector3 targetPosition, bool findClosest = false )
+	public async Task<ImmutableArray<Cell>> ComputePathParallel( Grid grid, Vector3 startingPosition, Vector3 targetPosition, bool findClosest = false )
 	{
 		var ctoken = new CancellationTokenSource();
 
 		var startingCell = grid.GetCell( startingPosition, findClosest );
 		var targetCell = grid.GetCell( targetPosition, findClosest );
 
-		var fromTo = ComputePath( startingCell, targetCell, ctoken.Token );
-		var toFrom = ComputePath( targetCell, startingCell, ctoken.Token, true );
+		var fromTo = ComputePathAsync( startingCell, targetCell, ctoken.Token );
+		var toFrom = ComputePathAsync( targetCell, startingCell, true, ctoken.Token );
 
 		var pathResult = await GameTask.WhenAny( fromTo, toFrom ).Result;
 
@@ -173,7 +133,7 @@ public partial class Grid
 		return pathResult;
 	}
 
-	void retracePath( ref List<Cell> pathList, Node startNode, Node targetNode )
+	private static void RetracePath( ImmutableArray<Cell>.Builder pathList, Node startNode, Node targetNode )
 	{
 		var currentNode = targetNode;
 

--- a/Grid-Astar-Library/code/Grid.cs
+++ b/Grid-Astar-Library/code/Grid.cs
@@ -93,8 +93,8 @@ public partial class Grid
 			cellsAtCoordinates = Cells.GetValueOrDefault( closestCoordinates );
 		}
 
-		if ( cellsAtCoordinates.Count == 1 ) return cellsAtCoordinates.First(); // If it's only one cell return it instantly
 		if ( cellsAtCoordinates == null ) return null; // Guess there were no cells at all??
+		if ( cellsAtCoordinates.Count == 1 ) return cellsAtCoordinates.First(); // If it's only one cell return it instantly
 
 		if ( onlyBelow )
 		{

--- a/Grid-Astar-Library/code/Grid.cs
+++ b/Grid-Astar-Library/code/Grid.cs
@@ -269,7 +269,7 @@ public partial class Grid
 
 		foreach ( var cellStack in Cells )
 			foreach ( var cell in cellStack.Value )
-				if ( cell.GetNeighbours().Count < 8 )
+				if ( cell.GetNeighbours().Count() < 8 )
 					outerCells.Add( cell );
 
 		return outerCells;

--- a/Grid-Astar-Library/code/HeapSort.cs
+++ b/Grid-Astar-Library/code/HeapSort.cs
@@ -12,7 +12,12 @@ public class Heap<T> where T : IHeapItem<T>
 
 	public Heap( int maxHeapSize )
 	{
-		items = new T[maxHeapSize];
+		items = ArrayPool<T>.Shared.Rent( maxHeapSize );
+	}
+
+	~Heap()
+	{
+		ArrayPool<T>.Shared.Return( items );
 	}
 
 	public void Add( T item )

--- a/Grid-Astar-Library/code/HeapSort.cs
+++ b/Grid-Astar-Library/code/HeapSort.cs
@@ -1,11 +1,14 @@
-﻿namespace GridAStar;
+﻿using System.Buffers;
+
+namespace GridAStar;
 
 // Thank you Debastian!
 public class Heap<T> where T : IHeapItem<T>
 {
+	public int Count => currentItemCount;
 
-	T[] items;
-	int currentItemCount;
+	private readonly T[] items;
+	private int currentItemCount;
 
 	public Heap( int maxHeapSize )
 	{
@@ -35,20 +38,12 @@ public class Heap<T> where T : IHeapItem<T>
 		SortUp( item );
 	}
 
-	public int Count
-	{
-		get
-		{
-			return currentItemCount;
-		}
-	}
-
 	public bool Contains( T item )
 	{
 		return Equals( items[item.HeapIndex], item );
 	}
 
-	void SortDown( T item )
+	private void SortDown( T item )
 	{
 		while ( true )
 		{
@@ -86,7 +81,7 @@ public class Heap<T> where T : IHeapItem<T>
 		}
 	}
 
-	void SortUp( T item )
+	private void SortUp( T item )
 	{
 		int parentIndex = (item.HeapIndex - 1) / 2;
 
@@ -106,7 +101,7 @@ public class Heap<T> where T : IHeapItem<T>
 		}
 	}
 
-	void Swap( T itemA, T itemB )
+	private void Swap( T itemA, T itemB )
 	{
 		items[itemA.HeapIndex] = itemB;
 		items[itemB.HeapIndex] = itemA;
@@ -114,16 +109,9 @@ public class Heap<T> where T : IHeapItem<T>
 		itemA.HeapIndex = itemB.HeapIndex;
 		itemB.HeapIndex = itemAIndex;
 	}
-
-
-
 }
 
 public interface IHeapItem<T> : IComparable<T>
 {
-	int HeapIndex
-	{
-		get;
-		set;
-	}
+	int HeapIndex { get; set; }
 }

--- a/Grid-Astar-Library/code/IntVector2.cs
+++ b/Grid-Astar-Library/code/IntVector2.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Like a Vector2, but with integers instead.
 /// </summary>
-public struct IntVector2
+public struct IntVector2 : IEquatable<IntVector2>
 {
 	public int x { get; set; }
 	public int y { get; set; }
@@ -64,5 +64,30 @@ public struct IntVector2
 	public override string ToString()
 	{
 		return $"{x},{y}";
+	}
+
+	public override bool Equals( object obj )
+	{
+		return obj is IntVector2 other && Equals( other );
+	}
+
+	public bool Equals( IntVector2 other )
+	{
+		return x == other.x && y == other.y;
+	}
+
+	public override int GetHashCode()
+	{
+		return HashCode.Combine( x, y );
+	}
+
+	public static bool operator ==( IntVector2 left, IntVector2 right )
+	{
+		return left.Equals( right );
+	}
+
+	public static bool operator !=( IntVector2 left, IntVector2 right )
+	{
+		return !(left == right);
 	}
 }


### PR DESCRIPTION
This PR greatly optimizes path computation.

## The Main Improvement
The main commit that increases performance is down to 77bb722. Making something [IEquatable<T>](https://learn.microsoft.com/en-us/dotnet/api/system.iequatable-1?view=net-7.0) allows for fast paths in generic collections such as the [Dictionary](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2?view=net-7.0). Using DotTrace to find hot paths in the call tree shows an enormous amount of time spent dealing with finding cells in dictionaries:

![image](https://user-images.githubusercontent.com/11802285/233811816-dfeb0366-2191-4634-a517-032426fa3ed4.png)

After applying the changes in the branch the tree looks more like this:

![image](https://user-images.githubusercontent.com/11802285/233811861-53248976-08e5-48ce-ac44-7c70055e6931.png)

## Refactoring compute methods
All of the `ComputePath*` methods have been edited:
- Asynchronous methods have "Async" tacked onto the name as is standard.
- All computing ends up in a single `ComputePathInternal` method. This removes the anonymous method that creates large closures around a lot of the required data. This also allows tools like DotTrace to actually see the method for analysis.
- `ComputePath*` now returns an `ImmutableArray<Cell>` instead of a `List<Cell>`. This does not change a whole lot but makes much more sense from an API stand point. Computed paths should be immutable.

## StressPath command
A new debug command is added as part of this to show the performance of path computing in an easier-to-read format. It works like the `TestPath` command and has a configurable amount of runs to execute and a seed for the random number generator that creates the target positions. This is used so you can have consistent paths created across multiple test runs.

Using this command with the old and new versions of the code shows the following results:
Before
![Old](https://user-images.githubusercontent.com/11802285/233812035-fd182bbd-4f66-4779-abef-0e3670e93b89.PNG)

After
![New](https://user-images.githubusercontent.com/11802285/233812037-c4aee8ad-1b12-4511-9b8c-a46d33f96383.PNG)